### PR TITLE
chore: opponentChoice accepts 1 <= x <= 3

### DIFF
--- a/src/components/partials/modal/AnalyzerModal.vue
+++ b/src/components/partials/modal/AnalyzerModal.vue
@@ -345,7 +345,7 @@ export default Vue.extend({
           result: this.formData.result,
           rank: ~~this.formData.rank!,
           myChoice: this.formData.myChoice,
-          opponentChoice: this.formData.opponentChoice,
+          opponentChoice: this.formData.opponentChoice.filter((id) => !!id),
           captureUrl: this.formData.captureUrl,
           note: this.formData.note,
           videoUrl: this.formData.videoUrl,
@@ -526,7 +526,7 @@ export default Vue.extend({
     disabled(): boolean {
       if (
         this.formData.myChoice.includes(0) ||
-        this.formData.opponentChoice.includes(0)
+        this.formData.opponentChoice[0] === 0 // 相手はポケモンが全部見えないことがあるため先発だけわかれば登録可能とする
       ) {
         return true
       }


### PR DESCRIPTION
resolve #6 

## About

現状相手の選出が見えない場合は登録できないが、 1 <= x <= 3 の範囲で登録を可能とした。

これによって相手が降参した場合や、相手の途中のポケモンに三タテされたデータも登録できるようになる。